### PR TITLE
Improve settings scrolling UX and recording feedback (Closes #2)

### DIFF
--- a/src/Geass/App.xaml.cs
+++ b/src/Geass/App.xaml.cs
@@ -202,7 +202,14 @@ public partial class App : Application
         };
 
         _audioCaptureService.RecordingStopped += OnRecordingAutoStopped;
-        _audioCaptureService.StartRecording();
+        if (!TryStartCaptureForCurrentWindow())
+        {
+            _state = AppState.Idle;
+            _transcriptionWindow?.Close();
+            _transcriptionWindow = null;
+            return;
+        }
+
         _transcriptionWindow.ShowRecording();
     }
 
@@ -218,10 +225,28 @@ public partial class App : Application
 
         _state = AppState.Streaming;
         _audioCaptureService.RecordingStopped -= OnRecordingAutoStopped;
+        _audioCaptureService.InputStatusChanged -= OnInputStatusChanged;
+        _audioCaptureService.InputLevelChanged -= OnInputLevelChanged;
 
         _transcriptionWindow?.ShowProcessing();
 
         var wavPath = await _audioCaptureService.StopRecording();
+        if (!_audioCaptureService.LastRecordingHadMeaningfulAudio)
+        {
+            try { File.Delete(wavPath); } catch { }
+            _state = AppState.Recording;
+            _screenAnalysisTask = null;
+            _transcriptionWindow?.ShowRecording();
+            _transcriptionWindow?.ShowTransientToast("No speech detected yet");
+            _audioCaptureService.RecordingStopped += OnRecordingAutoStopped;
+            if (!TryStartCaptureForCurrentWindow())
+            {
+                _state = AppState.Idle;
+                _transcriptionWindow?.Close();
+                _transcriptionWindow = null;
+            }
+            return;
+        }
 
         _transcriptionWindow?.ShowStreaming();
 
@@ -369,7 +394,12 @@ public partial class App : Application
         _transcriptionWindow.OnStopRecording = async () => await StopStyleRecordingAndReformat();
 
         _audioCaptureService.RecordingStopped += OnStyleRecordingAutoStopped;
-        _audioCaptureService.StartRecording();
+        if (!TryStartCaptureForCurrentWindow())
+        {
+            ReturnToEditing();
+            return;
+        }
+
         _transcriptionWindow.ShowStyleRecording();
     }
 
@@ -380,10 +410,23 @@ public partial class App : Application
 
         _state = AppState.StyleStreaming;
         _audioCaptureService.RecordingStopped -= OnStyleRecordingAutoStopped;
+        _audioCaptureService.InputStatusChanged -= OnInputStatusChanged;
+        _audioCaptureService.InputLevelChanged -= OnInputLevelChanged;
 
         _transcriptionWindow?.ShowStyleStreaming();
 
         var wavPath = await _audioCaptureService.StopRecording();
+        if (!_audioCaptureService.LastRecordingHadMeaningfulAudio)
+        {
+            try { File.Delete(wavPath); } catch { }
+            _state = AppState.StyleRecording;
+            _transcriptionWindow?.ShowStyleRecording();
+            _transcriptionWindow?.ShowTransientToast("No style instruction detected yet");
+            _audioCaptureService.RecordingStopped += OnStyleRecordingAutoStopped;
+            if (!TryStartCaptureForCurrentWindow())
+                ReturnToEditing();
+            return;
+        }
 
         _streamingCts = new CancellationTokenSource();
         _ = StreamStyleReformat(wavPath, _streamingCts.Token);
@@ -472,12 +515,16 @@ public partial class App : Application
         if (_state == AppState.Recording)
         {
             _audioCaptureService.RecordingStopped -= OnRecordingAutoStopped;
+            _audioCaptureService.InputStatusChanged -= OnInputStatusChanged;
+            _audioCaptureService.InputLevelChanged -= OnInputLevelChanged;
             _ = _audioCaptureService.StopRecording();
         }
 
         if (_state == AppState.StyleRecording)
         {
             _audioCaptureService.RecordingStopped -= OnStyleRecordingAutoStopped;
+            _audioCaptureService.InputStatusChanged -= OnInputStatusChanged;
+            _audioCaptureService.InputLevelChanged -= OnInputLevelChanged;
             _ = _audioCaptureService.StopRecording();
         }
 
@@ -504,6 +551,63 @@ public partial class App : Application
         });
 
         _state = AppState.Idle;
+    }
+
+    private void OnInputStatusChanged(AudioCaptureService.AudioInputStatus status)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            switch (status)
+            {
+                case AudioCaptureService.AudioInputStatus.Listening:
+                    _transcriptionWindow?.SetRecordingStatus(_state == AppState.StyleRecording ? "Style..." : "Listening...");
+                    break;
+                case AudioCaptureService.AudioInputStatus.Muted:
+                    _transcriptionWindow?.SetRecordingStatus("Microphone muted. Unmute to continue.", true);
+                    break;
+                case AudioCaptureService.AudioInputStatus.NoInput:
+                    if (_audioCaptureService.LastRecordingHadMeaningfulAudio)
+                        _transcriptionWindow?.SetRecordingStatus("Silence detected...", true);
+                    else
+                        _transcriptionWindow?.SetRecordingStatus(
+                            _state == AppState.StyleRecording ? "Waiting for style instruction..." : "Waiting for speech...");
+                    break;
+                case AudioCaptureService.AudioInputStatus.Clipping:
+                    _transcriptionWindow?.SetRecordingStatus("Input too loud (clipping). Move farther away.", true);
+                    break;
+            }
+        });
+    }
+
+    private void OnInputLevelChanged(float normalizedLevel)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            _transcriptionWindow?.SetInputLevel(normalizedLevel);
+        });
+    }
+
+    private bool TryStartCaptureForCurrentWindow()
+    {
+        _audioCaptureService.InputStatusChanged += OnInputStatusChanged;
+        _audioCaptureService.InputLevelChanged += OnInputLevelChanged;
+
+        try
+        {
+            _audioCaptureService.StartRecording();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _audioCaptureService.RecordingStopped -= OnRecordingAutoStopped;
+            _audioCaptureService.RecordingStopped -= OnStyleRecordingAutoStopped;
+            _audioCaptureService.InputStatusChanged -= OnInputStatusChanged;
+            _audioCaptureService.InputLevelChanged -= OnInputLevelChanged;
+
+            MessageBox.Show($"Unable to start microphone capture: {ex.Message}", "Geass",
+                MessageBoxButton.OK, MessageBoxImage.Warning);
+            return false;
+        }
     }
 
     private void ShowSettings()

--- a/src/Geass/Services/AudioCaptureService.cs
+++ b/src/Geass/Services/AudioCaptureService.cs
@@ -6,16 +6,38 @@ namespace Geass.Services;
 
 public class AudioCaptureService : IDisposable
 {
+    public enum AudioInputStatus
+    {
+        Listening,
+        Muted,
+        NoInput,
+        Clipping
+    }
+
     private static readonly TimeSpan MaxRecordingDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan SilenceWarningDelay = TimeSpan.FromSeconds(0.9);
+    private const float SignalThreshold = 0.015f;
+    private const float ClippingThreshold = 0.98f;
 
     private WasapiCapture? _capture;
+    private MMDevice? _captureDevice;
     private WaveFileWriter? _writer;
     private string? _rawFilePath;
     private string? _outputFilePath;
     private System.Threading.Timer? _maxDurationTimer;
+    private System.Threading.Timer? _inputHealthTimer;
     private readonly List<string> _tempFiles = [];
+    private DateTime _lastSignalAtUtc = DateTime.MinValue;
+    private DateTime _lastClippingAtUtc = DateTime.MinValue;
+    private DateTime _lastLevelEventAtUtc = DateTime.MinValue;
+    private float _smoothedLevel;
+    private AudioInputStatus _lastInputStatus = AudioInputStatus.Listening;
+
+    public bool LastRecordingHadMeaningfulAudio { get; private set; }
 
     public event Action? RecordingStopped;
+    public event Action<AudioInputStatus>? InputStatusChanged;
+    public event Action<float>? InputLevelChanged;
 
     public void StartRecording()
     {
@@ -28,6 +50,8 @@ public class AudioCaptureService : IDisposable
         _tempFiles.Add(_rawFilePath);
         _tempFiles.Add(_outputFilePath);
 
+        _captureDevice = GetDefaultCaptureDevice();
+        // Keep capture initialization compatible with prior behavior.
         _capture = new WasapiCapture();
         _capture.DataAvailable += OnDataAvailable;
         _capture.RecordingStopped += OnCaptureRecordingStopped;
@@ -35,8 +59,15 @@ public class AudioCaptureService : IDisposable
         // Record in native WASAPI format (typically 32-bit float, 48kHz)
         // No per-buffer resampling - convert after recording completes
         _writer = new WaveFileWriter(_rawFilePath, _capture.WaveFormat);
+        LastRecordingHadMeaningfulAudio = false;
+        _lastSignalAtUtc = DateTime.UtcNow;
+        _lastClippingAtUtc = DateTime.MinValue;
+        _lastLevelEventAtUtc = DateTime.MinValue;
+        _smoothedLevel = 0f;
+        _lastInputStatus = AudioInputStatus.Listening;
 
         _capture.StartRecording();
+        StartInputHealthMonitoring();
 
         _maxDurationTimer = new System.Threading.Timer(
             _ => StopRecordingInternal(),
@@ -104,6 +135,8 @@ public class AudioCaptureService : IDisposable
     {
         _maxDurationTimer?.Dispose();
         _maxDurationTimer = null;
+        _inputHealthTimer?.Dispose();
+        _inputHealthTimer = null;
 
         try
         {
@@ -120,13 +153,46 @@ public class AudioCaptureService : IDisposable
         if (_writer is null || e.BytesRecorded == 0)
             return;
 
-        // Write raw bytes in native format - no conversion needed
-        _writer.Write(e.Buffer, 0, e.BytesRecorded);
+        try
+        {
+            var (activity, peak) = ComputeInputLevels(e.Buffer, e.BytesRecorded, _capture?.WaveFormat);
+            var hasSignal = activity >= SignalThreshold;
+            if (hasSignal)
+            {
+                LastRecordingHadMeaningfulAudio = true;
+                _lastSignalAtUtc = DateTime.UtcNow;
+            }
+
+            if (peak >= ClippingThreshold)
+            {
+                _lastClippingAtUtc = DateTime.UtcNow;
+            }
+
+            // Smooth and throttle level updates to avoid UI churn.
+            _smoothedLevel = (_smoothedLevel * 0.82f) + (activity * 0.18f);
+            var now = DateTime.UtcNow;
+            if ((now - _lastLevelEventAtUtc) >= TimeSpan.FromMilliseconds(70))
+            {
+                _lastLevelEventAtUtc = now;
+                TryRaiseInputLevel(Math.Clamp(_smoothedLevel, 0f, 1f));
+            }
+        }
+        catch
+        {
+            // Never crash capture due to metering logic.
+        }
+
+        // Trim leading silence by writing only after speech begins.
+        if (LastRecordingHadMeaningfulAudio)
+        {
+            _writer.Write(e.Buffer, 0, e.BytesRecorded);
+        }
     }
 
     private void OnCaptureRecordingStopped(object? sender, StoppedEventArgs e)
     {
         CloseWriter();
+        TryRaiseInputLevel(0f);
         RecordingStopped?.Invoke();
     }
 
@@ -136,10 +202,178 @@ public class AudioCaptureService : IDisposable
         _writer = null;
     }
 
+    private MMDevice? GetDefaultCaptureDevice()
+    {
+        try
+        {
+            var enumerator = new MMDeviceEnumerator();
+            try
+            {
+                return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Console);
+            }
+            finally
+            {
+                enumerator.Dispose();
+            }
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private void StartInputHealthMonitoring()
+    {
+        _inputHealthTimer?.Dispose();
+        _inputHealthTimer = new System.Threading.Timer(_ => EvaluateInputHealth(), null, TimeSpan.Zero, TimeSpan.FromMilliseconds(350));
+    }
+
+    private void EvaluateInputHealth()
+    {
+        try
+        {
+            if (_capture is null || _capture.CaptureState != CaptureState.Capturing)
+                return;
+
+            var nowUtc = DateTime.UtcNow;
+            AudioInputStatus status;
+            var endpointVolume = _captureDevice?.AudioEndpointVolume?.MasterVolumeLevelScalar ?? 1f;
+
+            if (_captureDevice?.AudioEndpointVolume?.Mute == true || endpointVolume <= 0.001f)
+            {
+                status = AudioInputStatus.Muted;
+            }
+            else if ((nowUtc - _lastSignalAtUtc) > SilenceWarningDelay)
+            {
+                // Some hardware mute keys map to near-zero endpoint volume.
+                status = endpointVolume <= 0.05f ? AudioInputStatus.Muted : AudioInputStatus.NoInput;
+            }
+            else if ((nowUtc - _lastClippingAtUtc) < TimeSpan.FromSeconds(1.2))
+            {
+                status = AudioInputStatus.Clipping;
+            }
+            else
+            {
+                status = AudioInputStatus.Listening;
+            }
+
+            if (status == _lastInputStatus)
+                return;
+
+            _lastInputStatus = status;
+            InputStatusChanged?.Invoke(status);
+        }
+        catch
+        {
+            // Keep recording resilient even if endpoint polling fails.
+        }
+    }
+
+    private void TryRaiseInputLevel(float level)
+    {
+        try
+        {
+            InputLevelChanged?.Invoke(level);
+        }
+        catch
+        {
+            // UI subscriber issues should not terminate recording.
+        }
+    }
+
+    private static (float activity, float peak) ComputeInputLevels(byte[] buffer, int bytesRecorded, WaveFormat? waveFormat)
+    {
+        if (waveFormat is null || bytesRecorded <= 0)
+            return (0f, 0f);
+
+        var peak = 0f;
+        double sumSquares = 0;
+        var sampleCount = 0;
+        var bitsPerSample = waveFormat.BitsPerSample;
+        var channels = Math.Max(1, waveFormat.Channels);
+
+        if (waveFormat.Encoding == WaveFormatEncoding.IeeeFloat && bitsPerSample == 32)
+        {
+            for (var i = 0; i <= bytesRecorded - 4; i += 4)
+            {
+                var sample = BitConverter.ToSingle(buffer, i);
+                var abs = MathF.Abs(sample);
+                if (abs > peak) peak = abs;
+                sumSquares += sample * sample;
+                sampleCount++;
+            }
+            return ComputeActivity(peak, sumSquares, sampleCount);
+        }
+
+        if (bitsPerSample == 16)
+        {
+            for (var i = 0; i <= bytesRecorded - 2; i += 2)
+            {
+                var sample = BitConverter.ToInt16(buffer, i) / 32768f;
+                var abs = MathF.Abs(sample);
+                if (abs > peak) peak = abs;
+                sumSquares += sample * sample;
+                sampleCount++;
+            }
+            return ComputeActivity(peak, sumSquares, sampleCount);
+        }
+
+        if (bitsPerSample == 24)
+        {
+            for (var i = 0; i <= bytesRecorded - 3; i += 3)
+            {
+                var sample = (buffer[i + 2] << 24) | (buffer[i + 1] << 16) | (buffer[i] << 8);
+                sample >>= 8;
+                var normalized = sample / 8388608f;
+                var abs = MathF.Abs(normalized);
+                if (abs > peak) peak = abs;
+                sumSquares += normalized * normalized;
+                sampleCount++;
+            }
+            return ComputeActivity(peak, sumSquares, sampleCount);
+        }
+
+        if (bitsPerSample == 32)
+        {
+            for (var i = 0; i <= bytesRecorded - 4; i += 4)
+            {
+                var sample = BitConverter.ToInt32(buffer, i) / 2147483648f;
+                var abs = MathF.Abs(sample);
+                if (abs > peak) peak = abs;
+                sumSquares += sample * sample;
+                sampleCount++;
+            }
+            return ComputeActivity(peak, sumSquares, sampleCount);
+        }
+
+        // Fallback for uncommon formats: use average absolute byte amplitude.
+        for (var i = 0; i < bytesRecorded; i += channels)
+        {
+            var normalized = MathF.Abs((buffer[i] - 128) / 128f);
+            if (normalized > peak) peak = normalized;
+            sumSquares += normalized * normalized;
+            sampleCount++;
+        }
+        return ComputeActivity(peak, sumSquares, sampleCount);
+    }
+
+    private static (float activity, float peak) ComputeActivity(float peak, double sumSquares, int sampleCount)
+    {
+        if (sampleCount <= 0)
+            return (0f, peak);
+
+        var rms = (float)Math.Sqrt(sumSquares / sampleCount);
+        // Weighted blend lowers sensitivity to single-sample spikes.
+        var activity = Math.Clamp((rms * 2.2f) + (peak * 0.35f), 0f, 1f);
+        return (activity, peak);
+    }
+
     public void Dispose()
     {
         _maxDurationTimer?.Dispose();
+        _inputHealthTimer?.Dispose();
         _capture?.Dispose();
+        _captureDevice?.Dispose();
         CloseWriter();
 
         foreach (var file in _tempFiles)

--- a/src/Geass/ViewModels/SettingsViewModel.cs
+++ b/src/Geass/ViewModels/SettingsViewModel.cs
@@ -8,7 +8,7 @@ using Geass.Services;
 
 namespace Geass.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel : ObservableObject, IDisposable
 {
     private static readonly JsonSerializerOptions DisplayJsonOptions = new()
     {
@@ -20,6 +20,8 @@ public partial class SettingsViewModel : ObservableObject
     private readonly MemoryService _memoryService;
     private readonly GeminiService _geminiService;
     private readonly HotkeyService _hotkeyService;
+    private string _loadedFingerprint = "";
+    private bool _isLoading;
 
     [ObservableProperty]
     private string _apiKey = "";
@@ -68,6 +70,24 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private bool _enableScreenContext;
 
+    [ObservableProperty]
+    private bool _hasUnsavedChanges;
+
+    [ObservableProperty]
+    private bool _isSaving;
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    [ObservableProperty]
+    private bool _canEdit = true;
+
+    [ObservableProperty]
+    private string _statusMessage = "";
+
+    [ObservableProperty]
+    private bool _hasValidationError;
+
     public string[] AvailableModels => GeminiModels.Available;
 
     public SettingsViewModel(SettingsService settingsService, MemoryService memoryService, GeminiService geminiService, HotkeyService hotkeyService)
@@ -88,22 +108,24 @@ public partial class SettingsViewModel : ObservableObject
             IsMemoryUpdating = isUpdating;
 
             // Reload memory when background update finishes
-            if (!isUpdating)
+            if (!isUpdating && !HasUnsavedChanges)
             {
                 var memory = await _memoryService.LoadAsync();
                 MemoryJson = JsonSerializer.Serialize(memory, DisplayJsonOptions);
                 EstimatedTokens = _memoryService.EstimateTokens(memory);
+                MarkClean();
             }
         });
     }
 
     public async Task LoadAsync()
     {
+        _isLoading = true;
         var settings = await _settingsService.LoadAsync();
-        ApiKey = settings.GeminiApiKey;
+        ApiKey = settings.GeminiApiKey.Trim();
         SelectedTranscriptionModel = settings.TranscriptionModel;
         SelectedAnalysisModel = settings.AnalysisModel;
-        Language = settings.Language;
+        Language = string.IsNullOrWhiteSpace(settings.Language) ? TranscriptionLanguages.Default : settings.Language.Trim();
         EnableScreenContext = settings.EnableScreenContext;
 
         _hotkeyKey = HotkeyService.ParseKey(settings.HotkeyKey);
@@ -116,6 +138,13 @@ public partial class SettingsViewModel : ObservableObject
         var memory = await _memoryService.LoadAsync();
         MemoryJson = JsonSerializer.Serialize(memory, DisplayJsonOptions);
         EstimatedTokens = _memoryService.EstimateTokens(memory);
+
+        SaveButtonText = "Save";
+        StatusMessage = "";
+        HasValidationError = false;
+        _isLoading = false;
+        MarkClean();
+        NotifyCommandStates();
     }
 
     partial void OnIsRecordingHotkeyChanged(bool value)
@@ -132,6 +161,7 @@ public partial class SettingsViewModel : ObservableObject
         _hotkeyModifier = modifier;
         HotkeyDisplay = HotkeyService.FormatHotkey(modifier, key);
         IsRecordingHotkey = false;
+        TrackUnsavedChanges();
     }
 
     public void SetStyleKey(Key key)
@@ -139,6 +169,7 @@ public partial class SettingsViewModel : ObservableObject
         _styleKey = key;
         StyleKeyDisplay = FormatKeyName(key);
         IsRecordingStyleKey = false;
+        TrackUnsavedChanges();
     }
 
     public static string FormatKeyName(Key key) => key switch
@@ -157,36 +188,100 @@ public partial class SettingsViewModel : ObservableObject
         _ => key.ToString()
     };
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanSave))]
     private async Task SaveAsync()
     {
-        var settings = new AppSettings
+        if (IsBusy) return;
+
+        if (!TryBuildSettingsForSave(out var settings, out var memory, out var validationMessage))
         {
-            GeminiApiKey = ApiKey,
+            HasValidationError = true;
+            StatusMessage = validationMessage;
+            SaveButtonText = "Save";
+            return;
+        }
+
+        IsSaving = true;
+        SaveButtonText = "Saving...";
+        StatusMessage = "";
+        HasValidationError = false;
+
+        try
+        {
+            await _settingsService.SaveAsync(settings);
+            await _memoryService.SaveAsync(memory);
+
+            SaveButtonText = "Saved!";
+            IsSaved = true;
+            HasValidationError = false;
+            StatusMessage = "Settings saved";
+            MarkClean();
+            await Task.Delay(1200);
+        }
+        finally
+        {
+            SaveButtonText = "Save";
+            IsSaved = false;
+            IsSaving = false;
+        }
+    }
+
+    private bool TryBuildSettingsForSave(out AppSettings settings, out MemoryStore memory, out string validationMessage)
+    {
+        settings = new AppSettings();
+        memory = new MemoryStore();
+        validationMessage = "";
+
+        var normalizedApiKey = (ApiKey ?? "").Trim();
+        var normalizedLanguage = string.IsNullOrWhiteSpace(Language) ? TranscriptionLanguages.Default : Language.Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizedApiKey))
+        {
+            validationMessage = "API key is required.";
+            return false;
+        }
+
+        try
+        {
+            memory = JsonSerializer.Deserialize<MemoryStore>(MemoryJson) ?? new MemoryStore();
+        }
+        catch (JsonException)
+        {
+            validationMessage = "Memory JSON is invalid. Fix it before saving.";
+            return false;
+        }
+
+        settings = new AppSettings
+        {
+            GeminiApiKey = normalizedApiKey,
             TranscriptionModel = SelectedTranscriptionModel,
             AnalysisModel = SelectedAnalysisModel,
-            Language = Language,
+            Language = normalizedLanguage,
             HotkeyKey = _hotkeyKey.ToString(),
             HotkeyModifier = _hotkeyModifier.ToString(),
             EnableScreenContext = EnableScreenContext,
             StyleKey = _styleKey.ToString()
         };
-        await _settingsService.SaveAsync(settings);
 
-        var memory = JsonSerializer.Deserialize<MemoryStore>(MemoryJson) ?? new MemoryStore();
-        await _memoryService.SaveAsync(memory);
-
-        SaveButtonText = "Saved!";
-        IsSaved = true;
-        await Task.Delay(1500);
-        SaveButtonText = "Save";
-        IsSaved = false;
+        // Keep normalized values in the UI after successful validation.
+        ApiKey = normalizedApiKey;
+        Language = normalizedLanguage;
+        return true;
     }
 
-    [RelayCommand]
+    private bool CanSave()
+    {
+        return !IsBusy && HasUnsavedChanges;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRunMemoryActions))]
     private async Task OptimizeMemoryAsync()
     {
+        if (IsBusy) return;
+
         IsMemoryUpdating = true;
+        HasValidationError = false;
+        StatusMessage = "";
         try
         {
             var memory = JsonSerializer.Deserialize<MemoryStore>(MemoryJson) ?? new MemoryStore();
@@ -194,22 +289,128 @@ public partial class SettingsViewModel : ObservableObject
             MemoryJson = JsonSerializer.Serialize(optimized, DisplayJsonOptions);
             EstimatedTokens = _memoryService.EstimateTokens(optimized);
         }
+        catch (JsonException)
+        {
+            HasValidationError = true;
+            StatusMessage = "Memory JSON is invalid. Fix it before optimizing.";
+        }
         finally
         {
             IsMemoryUpdating = false;
         }
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanRunMemoryActions))]
     private void ClearMemory()
     {
+        if (IsBusy) return;
+
         var empty = new MemoryStore();
         MemoryJson = JsonSerializer.Serialize(empty, DisplayJsonOptions);
         EstimatedTokens = _memoryService.EstimateTokens(empty);
+        HasValidationError = false;
+        StatusMessage = "";
+    }
+
+    private bool CanRunMemoryActions()
+    {
+        return !IsBusy;
+    }
+
+    private void TrackUnsavedChanges()
+    {
+        if (_isLoading) return;
+
+        var hasChanges = BuildFingerprint() != _loadedFingerprint;
+        if (HasUnsavedChanges != hasChanges)
+        {
+            HasUnsavedChanges = hasChanges;
+        }
+    }
+
+    private void MarkClean()
+    {
+        _loadedFingerprint = BuildFingerprint();
+        HasUnsavedChanges = false;
+    }
+
+    private string BuildFingerprint()
+    {
+        return string.Join("|",
+            (ApiKey ?? "").Trim(),
+            SelectedTranscriptionModel ?? "",
+            SelectedAnalysisModel ?? "",
+            (Language ?? "").Trim(),
+            _hotkeyKey,
+            _hotkeyModifier,
+            EnableScreenContext,
+            _styleKey,
+            (MemoryJson ?? "").Trim());
+    }
+
+    private void UpdateBusyState()
+    {
+        IsBusy = IsSaving || IsMemoryUpdating;
+        CanEdit = !IsBusy;
+        NotifyCommandStates();
+    }
+
+    private void NotifyCommandStates()
+    {
+        SaveCommand.NotifyCanExecuteChanged();
+        OptimizeMemoryCommand.NotifyCanExecuteChanged();
+        ClearMemoryCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnApiKeyChanged(string value)
+    {
+        TrackUnsavedChanges();
+    }
+
+    partial void OnSelectedTranscriptionModelChanged(string value)
+    {
+        TrackUnsavedChanges();
+    }
+
+    partial void OnSelectedAnalysisModelChanged(string value)
+    {
+        TrackUnsavedChanges();
+    }
+
+    partial void OnLanguageChanged(string value)
+    {
+        TrackUnsavedChanges();
+    }
+
+    partial void OnEnableScreenContextChanged(bool value)
+    {
+        TrackUnsavedChanges();
+    }
+
+    partial void OnHasUnsavedChangesChanged(bool value)
+    {
+        NotifyCommandStates();
+    }
+
+    partial void OnIsSavingChanged(bool value)
+    {
+        UpdateBusyState();
+    }
+
+    partial void OnIsMemoryUpdatingChanged(bool value)
+    {
+        UpdateBusyState();
+    }
+
+    public void Dispose()
+    {
+        _memoryService.IsUpdatingChanged -= OnMemoryUpdatingChanged;
     }
 
     partial void OnMemoryJsonChanged(string value)
     {
+        TrackUnsavedChanges();
+
         try
         {
             var memory = JsonSerializer.Deserialize<MemoryStore>(value);

--- a/src/Geass/Views/SettingsWindow.xaml
+++ b/src/Geass/Views/SettingsWindow.xaml
@@ -3,7 +3,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Geass.ViewModels"
         Width="460"
-        SizeToContent="Height"
+        Height="760"
+        MinHeight="620"
+        MaxHeight="{x:Static SystemParameters.MaximizedPrimaryScreenHeight}"
         WindowStartupLocation="CenterScreen"
         Title="Geass Settings"
         ResizeMode="NoResize"
@@ -28,343 +30,444 @@
     </Window.Resources>
 
     <Border Style="{StaticResource CardStyle}" Margin="0">
-        <StackPanel Margin="20,18,20,18">
+        <Grid Margin="20,18,20,18">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
 
             <!-- Header -->
-            <StackPanel Orientation="Horizontal" Margin="0,0,0,14">
-                <Ellipse Width="22" Height="22" Margin="0,0,8,0">
-                    <Ellipse.Fill>
+            <Grid Grid.Row="0" Margin="0,0,0,14">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="0" Orientation="Horizontal">
+                    <Ellipse Width="22" Height="22" Margin="0,0,8,0">
+                        <Ellipse.Fill>
+                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                                <GradientStop Color="#FF6B9D" Offset="0" />
+                                <GradientStop Color="#FF8FB4" Offset="1" />
+                            </LinearGradientBrush>
+                        </Ellipse.Fill>
+                    </Ellipse>
+                    <TextBlock Text="Settings"
+                               Style="{StaticResource BaseTextStyle}"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               VerticalAlignment="Center" />
+                </StackPanel>
+
+                <Border Grid.Column="1"
+                        VerticalAlignment="Center"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="8,4"
+                        Visibility="{Binding HasUnsavedChanges, Converter={StaticResource BoolToVisibility}}">
+                    <Border.Background>
                         <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                            <GradientStop Color="#FF6B9D" Offset="0" />
-                            <GradientStop Color="#FF8FB4" Offset="1" />
+                            <GradientStop Color="#26FF6B9D" Offset="0" />
+                            <GradientStop Color="#1AFF8FB4" Offset="1" />
                         </LinearGradientBrush>
-                    </Ellipse.Fill>
-                </Ellipse>
-                <TextBlock Text="Settings"
-                           Style="{StaticResource BaseTextStyle}"
-                           FontSize="16"
-                           FontWeight="SemiBold"
-                           VerticalAlignment="Center" />
-            </StackPanel>
+                    </Border.Background>
+                    <Border.BorderBrush>
+                        <SolidColorBrush Color="#55FF6B9D" />
+                    </Border.BorderBrush>
+                    <Border.Effect>
+                        <DropShadowEffect BlurRadius="10"
+                                          Opacity="0.18"
+                                          Direction="270"
+                                          ShadowDepth="1"
+                                          Color="#FF6B9D" />
+                    </Border.Effect>
 
-            <!-- API Key Section -->
-            <Border Style="{StaticResource SectionCardStyle}">
-                <StackPanel>
-                    <TextBlock Text="API KEY" Style="{StaticResource SectionLabelStyle}" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-
-                        <PasswordBox x:Name="ApiKeyPasswordBox"
-                                     Grid.Column="0"
-                                     Style="{StaticResource PasswordInputStyle}"
-                                     PasswordChanged="ApiKeyPasswordBox_PasswordChanged" />
-
-                        <TextBox x:Name="ApiKeyTextBox"
-                                 Grid.Column="0"
-                                 Style="{StaticResource TextInputStyle}"
-                                 FontSize="13"
-                                 Text="{Binding ApiKey, UpdateSourceTrigger=PropertyChanged}"
-                                 Visibility="Collapsed" />
-
-                        <ToggleButton x:Name="ShowPasswordToggle"
-                                      Grid.Column="1"
-                                      Width="28" Height="28"
-                                      Margin="4,0,0,0"
-                                      Background="Transparent"
-                                      BorderThickness="0"
-                                      Cursor="Hand"
-                                      Click="ShowPasswordToggle_Click">
-                            <Path x:Name="EyeIcon"
-                                  Width="15" Height="15"
-                                  Stretch="Uniform"
-                                  Fill="{StaticResource TextSecondaryBrush}"
-                                  Data="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12,17c-2.76,0-5-2.24-5-5s2.24-5 5-5 5,2.24 5,5-2.24,5-5,5zM12,9c-1.66,0-3,1.34-3,3s1.34,3 3,3 3-1.34 3-3-1.34-3-3-3z" />
-                        </ToggleButton>
-                    </Grid>
-                </StackPanel>
-            </Border>
-
-            <!-- Models Section -->
-            <Border Style="{StaticResource SectionCardStyle}">
-                <StackPanel>
-                    <TextBlock Text="MODELS" Style="{StaticResource SectionLabelStyle}" />
-
-                    <Grid Margin="0,0,0,6">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="90" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
-                                   Text="Transcription"
-                                   Style="{StaticResource BaseTextStyle}"
-                                   FontSize="12"
-                                   VerticalAlignment="Center" />
-                        <ComboBox Grid.Column="1"
-                                  Style="{StaticResource FlatComboBoxStyle}"
-                                  ItemContainerStyle="{StaticResource FlatComboBoxItemStyle}"
-                                  ItemsSource="{Binding AvailableModels}"
-                                  SelectedItem="{Binding SelectedTranscriptionModel}" />
-                    </Grid>
-
-                    <Grid Margin="0,0,0,6">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="90" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
-                                   Text="Analysis"
-                                   Style="{StaticResource BaseTextStyle}"
-                                   FontSize="12"
-                                   VerticalAlignment="Center" />
-                        <ComboBox Grid.Column="1"
-                                  Style="{StaticResource FlatComboBoxStyle}"
-                                  ItemContainerStyle="{StaticResource FlatComboBoxItemStyle}"
-                                  ItemsSource="{Binding AvailableModels}"
-                                  SelectedItem="{Binding SelectedAnalysisModel}" />
-                    </Grid>
-
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="90" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
-                                   Text="Language"
-                                   Style="{StaticResource BaseTextStyle}"
-                                   FontSize="12"
-                                   VerticalAlignment="Center" />
-                        <TextBox Grid.Column="1"
-                                 Style="{StaticResource TextInputStyle}"
-                                 FontSize="13"
-                                 Text="{Binding Language, UpdateSourceTrigger=PropertyChanged}" />
-                    </Grid>
-                </StackPanel>
-            </Border>
-
-            <!-- Screen Context Section -->
-            <Border Style="{StaticResource SectionCardStyle}">
-                <StackPanel>
-                    <TextBlock Text="SCREEN CONTEXT" Style="{StaticResource SectionLabelStyle}" />
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
-                                   Text="Send screenshot to AI"
-                                   Style="{StaticResource BaseTextStyle}"
-                                   FontSize="12"
-                                   VerticalAlignment="Center" />
-                        <CheckBox Grid.Column="1"
-                                  Style="{StaticResource ToggleSwitchStyle}"
-                                  IsChecked="{Binding EnableScreenContext}"
-                                  VerticalAlignment="Center" />
-                    </Grid>
-                    <TextBlock Text="Captures active window when recording starts to improve transcription accuracy"
-                               Style="{StaticResource HintTextStyle}"
-                               TextWrapping="Wrap" />
-                </StackPanel>
-            </Border>
-
-            <!-- Shortcut Section -->
-            <Border Style="{StaticResource SectionCardStyle}">
-                <StackPanel>
-                    <TextBlock Text="SHORTCUT" Style="{StaticResource SectionLabelStyle}" />
-                    <Border x:Name="HotkeyRecorder"
-                            Background="White"
-                            BorderBrush="{StaticResource BorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="8"
-                            Padding="10,7"
-                            Cursor="Hand"
-                            Focusable="True"
-                            MouseDown="HotkeyRecorder_MouseDown"
-                            KeyDown="HotkeyRecorder_KeyDown"
-                            LostFocus="HotkeyRecorder_LostFocus">
-                        <Grid>
-                            <TextBlock Text="{Binding HotkeyDisplay}"
-                                       FontSize="13"
-                                       FontFamily="{StaticResource AppFontFamily}"
-                                       Foreground="{StaticResource TextPrimaryBrush}"
-                                       VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsRecordingHotkey}" Value="True">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                            <TextBlock Text="Press shortcut..."
-                                       FontSize="13"
-                                       FontFamily="{StaticResource AppFontFamily}"
-                                       Foreground="{StaticResource TextSecondaryBrush}"
-                                       VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsRecordingHotkey}" Value="False">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                        </Grid>
-                    </Border>
-                    <TextBlock Text="Click to change, then press new shortcut"
-                               Style="{StaticResource HintTextStyle}" />
-
-                    <TextBlock Text="STYLE KEY" Style="{StaticResource SectionLabelStyle}" Margin="0,10,0,0" />
-                    <Border x:Name="StyleKeyRecorder"
-                            Background="White"
-                            BorderBrush="{StaticResource BorderBrush}"
-                            BorderThickness="1"
-                            CornerRadius="8"
-                            Padding="10,7"
-                            Cursor="Hand"
-                            Focusable="True"
-                            MouseDown="StyleKeyRecorder_MouseDown"
-                            KeyDown="StyleKeyRecorder_KeyDown"
-                            LostFocus="StyleKeyRecorder_LostFocus">
-                        <Grid>
-                            <TextBlock Text="{Binding StyleKeyDisplay}"
-                                       FontSize="13"
-                                       FontFamily="{StaticResource AppFontFamily}"
-                                       Foreground="{StaticResource TextPrimaryBrush}"
-                                       VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsRecordingStyleKey}" Value="True">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                            <TextBlock Text="Press key..."
-                                       FontSize="13"
-                                       FontFamily="{StaticResource AppFontFamily}"
-                                       Foreground="{StaticResource TextSecondaryBrush}"
-                                       VerticalAlignment="Center">
-                                <TextBlock.Style>
-                                    <Style TargetType="TextBlock">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsRecordingStyleKey}" Value="False">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </TextBlock.Style>
-                            </TextBlock>
-                        </Grid>
-                    </Border>
-                    <TextBlock Text="Key to trigger style conversion during editing"
-                               Style="{StaticResource HintTextStyle}" />
-                </StackPanel>
-            </Border>
-
-            <!-- Memory Section -->
-            <Border Style="{StaticResource SectionCardStyle}">
-                <StackPanel>
-                    <Grid Margin="0,0,0,6">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0"
-                                   Text="MEMORY"
-                                   Style="{StaticResource SectionLabelStyle}"
-                                   Margin="0" />
-
-                        <!-- Updating spinner -->
-                        <Grid Grid.Column="1"
-                              Margin="6,0,0,0"
-                              VerticalAlignment="Center"
-                              Visibility="{Binding IsMemoryUpdating, Converter={StaticResource BoolToVisibility}}">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <Ellipse x:Name="MemorySpinner"
-                                         Width="11" Height="11"
-                                         StrokeThickness="1.5"
-                                         Stroke="{StaticResource AccentBrush}"
-                                         StrokeDashArray="2.5 1.5"
-                                         RenderTransformOrigin="0.5,0.5">
-                                    <Ellipse.RenderTransform>
-                                        <RotateTransform Angle="0" />
-                                    </Ellipse.RenderTransform>
-                                </Ellipse>
-                                <TextBlock Text="Updating..."
-                                           FontSize="10"
-                                           Foreground="{StaticResource AccentBrush}"
-                                           Margin="4,0,0,0"
-                                           VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Grid>
-
-                        <TextBlock Grid.Column="3"
-                                   Style="{StaticResource HintTextStyle}"
-                                   FontSize="11"
-                                   Margin="0"
-                                   VerticalAlignment="Center">
-                            <Run Text="{Binding EstimatedTokens, Mode=OneWay}" />
-                            <Run Text=" tokens" />
-                        </TextBlock>
-                    </Grid>
-                    <TextBox Style="{StaticResource TextInputStyle}"
-                             AcceptsReturn="True"
-                             TextWrapping="Wrap"
-                             FontFamily="Consolas, Courier New, monospace"
-                             FontSize="11.5"
-                             Height="160"
-                             VerticalScrollBarVisibility="Auto"
-                             Text="{Binding MemoryJson, UpdateSourceTrigger=PropertyChanged}" />
-                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                        <Button Content="Optimize"
-                                Style="{StaticResource GhostButtonStyle}"
-                                Padding="8,4"
-                                FontSize="11.5"
-                                Command="{Binding OptimizeMemoryCommand}"
-                                ToolTip="Compress memory using AI to stay within token limits"
-                                Margin="0,0,4,0" />
-                        <Button Content="Clear"
-                                Style="{StaticResource GhostButtonStyle}"
-                                Padding="8,4"
-                                FontSize="11.5"
-                                Command="{Binding ClearMemoryCommand}"
-                                ToolTip="Delete all memory data" />
+                    <StackPanel Orientation="Horizontal">
+                        <Rectangle Width="6"
+                                   Height="6"
+                                   RadiusX="1.5"
+                                   RadiusY="1.5"
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,6,0"
+                                   Fill="{StaticResource AccentBrush}" />
+                        <TextBlock Text="Unsaved changes"
+                                   FontFamily="{StaticResource AppFontFamily}"
+                                   FontWeight="SemiBold"
+                                   FontSize="11.5"
+                                   Foreground="{StaticResource AccentBrush}" />
                     </StackPanel>
+                </Border>
+            </Grid>
+
+            <!-- Scrollable Content -->
+            <ScrollViewer Grid.Row="1"
+                          IsEnabled="{Binding CanEdit}"
+                          VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled"
+                          Margin="0,0,0,12">
+                <StackPanel>
+                    <!-- API Key Section -->
+                    <Border Style="{StaticResource SectionCardStyle}">
+                        <StackPanel>
+                            <TextBlock Text="API KEY" Style="{StaticResource SectionLabelStyle}" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <PasswordBox x:Name="ApiKeyPasswordBox"
+                                             Grid.Column="0"
+                                             Style="{StaticResource PasswordInputStyle}"
+                                             PasswordChanged="ApiKeyPasswordBox_PasswordChanged" />
+
+                                <TextBox x:Name="ApiKeyTextBox"
+                                         Grid.Column="0"
+                                         Style="{StaticResource TextInputStyle}"
+                                         FontSize="13"
+                                         Text="{Binding ApiKey, UpdateSourceTrigger=PropertyChanged}"
+                                         Visibility="Collapsed" />
+
+                                <ToggleButton x:Name="ShowPasswordToggle"
+                                              Grid.Column="1"
+                                              Width="28" Height="28"
+                                              Margin="4,0,0,0"
+                                              Background="Transparent"
+                                              BorderThickness="0"
+                                              Cursor="Hand"
+                                              Click="ShowPasswordToggle_Click">
+                                    <Path x:Name="EyeIcon"
+                                          Width="15" Height="15"
+                                          Stretch="Uniform"
+                                          Fill="{StaticResource TextSecondaryBrush}"
+                                          Data="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12,17c-2.76,0-5-2.24-5-5s2.24-5 5-5 5,2.24 5,5-2.24,5-5,5zM12,9c-1.66,0-3,1.34-3,3s1.34,3 3,3 3-1.34 3-3-1.34-3-3-3z" />
+                                </ToggleButton>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Models Section -->
+                    <Border Style="{StaticResource SectionCardStyle}">
+                        <StackPanel>
+                            <TextBlock Text="MODELS" Style="{StaticResource SectionLabelStyle}" />
+
+                            <Grid Margin="0,0,0,6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="Transcription"
+                                           Style="{StaticResource BaseTextStyle}"
+                                           FontSize="12"
+                                           VerticalAlignment="Center" />
+                                <ComboBox Grid.Column="1"
+                                          Style="{StaticResource FlatComboBoxStyle}"
+                                          ItemContainerStyle="{StaticResource FlatComboBoxItemStyle}"
+                                          ItemsSource="{Binding AvailableModels}"
+                                          SelectedItem="{Binding SelectedTranscriptionModel}" />
+                            </Grid>
+
+                            <Grid Margin="0,0,0,6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="Analysis"
+                                           Style="{StaticResource BaseTextStyle}"
+                                           FontSize="12"
+                                           VerticalAlignment="Center" />
+                                <ComboBox Grid.Column="1"
+                                          Style="{StaticResource FlatComboBoxStyle}"
+                                          ItemContainerStyle="{StaticResource FlatComboBoxItemStyle}"
+                                          ItemsSource="{Binding AvailableModels}"
+                                          SelectedItem="{Binding SelectedAnalysisModel}" />
+                            </Grid>
+
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="90" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="Language"
+                                           Style="{StaticResource BaseTextStyle}"
+                                           FontSize="12"
+                                           VerticalAlignment="Center" />
+                                <TextBox Grid.Column="1"
+                                         Style="{StaticResource TextInputStyle}"
+                                         FontSize="13"
+                                         Text="{Binding Language, UpdateSourceTrigger=PropertyChanged}" />
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Screen Context Section -->
+                    <Border Style="{StaticResource SectionCardStyle}">
+                        <StackPanel>
+                            <TextBlock Text="SCREEN CONTEXT" Style="{StaticResource SectionLabelStyle}" />
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="Send screenshot to AI"
+                                           Style="{StaticResource BaseTextStyle}"
+                                           FontSize="12"
+                                           VerticalAlignment="Center" />
+                                <CheckBox Grid.Column="1"
+                                          Style="{StaticResource ToggleSwitchStyle}"
+                                          IsChecked="{Binding EnableScreenContext}"
+                                          VerticalAlignment="Center" />
+                            </Grid>
+                            <TextBlock Text="Captures active window when recording starts to improve transcription accuracy"
+                                       Style="{StaticResource HintTextStyle}"
+                                       TextWrapping="Wrap" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Shortcut Section -->
+                    <Border Style="{StaticResource SectionCardStyle}">
+                        <StackPanel>
+                            <TextBlock Text="SHORTCUT" Style="{StaticResource SectionLabelStyle}" />
+                            <Border x:Name="HotkeyRecorder"
+                                    Background="White"
+                                    BorderBrush="{StaticResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="10,7"
+                                    Cursor="Hand"
+                                    Focusable="True"
+                                    MouseDown="HotkeyRecorder_MouseDown"
+                                    KeyDown="HotkeyRecorder_KeyDown"
+                                    LostFocus="HotkeyRecorder_LostFocus">
+                                <Grid>
+                                    <TextBlock Text="{Binding HotkeyDisplay}"
+                                               FontSize="13"
+                                               FontFamily="{StaticResource AppFontFamily}"
+                                               Foreground="{StaticResource TextPrimaryBrush}"
+                                               VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsRecordingHotkey}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Text="Press shortcut..."
+                                               FontSize="13"
+                                               FontFamily="{StaticResource AppFontFamily}"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsRecordingHotkey}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
+                            <TextBlock Text="Click to change, then press new shortcut"
+                                       Style="{StaticResource HintTextStyle}" />
+
+                            <TextBlock Text="STYLE KEY" Style="{StaticResource SectionLabelStyle}" Margin="0,10,0,0" />
+                            <Border x:Name="StyleKeyRecorder"
+                                    Background="White"
+                                    BorderBrush="{StaticResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="8"
+                                    Padding="10,7"
+                                    Cursor="Hand"
+                                    Focusable="True"
+                                    MouseDown="StyleKeyRecorder_MouseDown"
+                                    KeyDown="StyleKeyRecorder_KeyDown"
+                                    LostFocus="StyleKeyRecorder_LostFocus">
+                                <Grid>
+                                    <TextBlock Text="{Binding StyleKeyDisplay}"
+                                               FontSize="13"
+                                               FontFamily="{StaticResource AppFontFamily}"
+                                               Foreground="{StaticResource TextPrimaryBrush}"
+                                               VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsRecordingStyleKey}" Value="True">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Text="Press key..."
+                                               FontSize="13"
+                                               FontFamily="{StaticResource AppFontFamily}"
+                                               Foreground="{StaticResource TextSecondaryBrush}"
+                                               VerticalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsRecordingStyleKey}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                </Grid>
+                            </Border>
+                            <TextBlock Text="Key to trigger style conversion during editing"
+                                       Style="{StaticResource HintTextStyle}" />
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Memory Section -->
+                    <Border Style="{StaticResource SectionCardStyle}">
+                        <StackPanel>
+                            <Grid Margin="0,0,0,6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0"
+                                           Text="MEMORY"
+                                           Style="{StaticResource SectionLabelStyle}"
+                                           Margin="0" />
+
+                                <!-- Updating spinner -->
+                                <Grid Grid.Column="1"
+                                      Margin="6,0,0,0"
+                                      VerticalAlignment="Center"
+                                      Visibility="{Binding IsMemoryUpdating, Converter={StaticResource BoolToVisibility}}">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <Ellipse x:Name="MemorySpinner"
+                                                 Width="11" Height="11"
+                                                 StrokeThickness="1.5"
+                                                 Stroke="{StaticResource AccentBrush}"
+                                                 StrokeDashArray="2.5 1.5"
+                                                 RenderTransformOrigin="0.5,0.5">
+                                            <Ellipse.RenderTransform>
+                                                <RotateTransform Angle="0" />
+                                            </Ellipse.RenderTransform>
+                                        </Ellipse>
+                                        <TextBlock Text="Updating..."
+                                                   FontSize="10"
+                                                   Foreground="{StaticResource AccentBrush}"
+                                                   Margin="4,0,0,0"
+                                                   VerticalAlignment="Center" />
+                                    </StackPanel>
+                                </Grid>
+
+                                <TextBlock Grid.Column="3"
+                                           Style="{StaticResource HintTextStyle}"
+                                           FontSize="11"
+                                           Margin="0"
+                                           VerticalAlignment="Center">
+                                    <Run Text="{Binding EstimatedTokens, Mode=OneWay}" />
+                                    <Run Text=" tokens" />
+                                </TextBlock>
+                            </Grid>
+                            <TextBox Style="{StaticResource TextInputStyle}"
+                                     AcceptsReturn="True"
+                                     TextWrapping="Wrap"
+                                     FontFamily="Consolas, Courier New, monospace"
+                                     FontSize="11.5"
+                                     Height="160"
+                                     VerticalScrollBarVisibility="Auto"
+                                     Text="{Binding MemoryJson, UpdateSourceTrigger=PropertyChanged}" />
+                            <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                <Button Content="Optimize"
+                                        Style="{StaticResource GhostButtonStyle}"
+                                        Padding="8,4"
+                                        FontSize="11.5"
+                                        Command="{Binding OptimizeMemoryCommand}"
+                                        ToolTip="Compress memory using AI to stay within token limits"
+                                        Margin="0,0,4,0" />
+                                <Button Content="Clear"
+                                        Style="{StaticResource GhostButtonStyle}"
+                                        Padding="8,4"
+                                        FontSize="11.5"
+                                        Command="{Binding ClearMemoryCommand}"
+                                        ToolTip="Delete all memory data" />
+                            </StackPanel>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </ScrollViewer>
+
+            <!-- Sticky Save Bar -->
+            <Border Grid.Row="2"
+                    BorderBrush="{StaticResource BorderBrush}"
+                    BorderThickness="0,1,0,0"
+                    Padding="0,10,0,0">
+                <StackPanel>
+                    <TextBlock Text="{Binding StatusMessage}"
+                               Margin="0,0,0,8"
+                               FontSize="11.5"
+                               FontFamily="{StaticResource AppFontFamily}">
+                        <TextBlock.Style>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding HasValidationError}" Value="True">
+                                        <Setter Property="Foreground">
+                                            <Setter.Value>
+                                                <SolidColorBrush Color="#D64545" />
+                                            </Setter.Value>
+                                        </Setter>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+
+                        <Button Grid.Column="0"
+                                Content="Cancel"
+                                Click="CancelButton_Click"
+                                Style="{StaticResource GhostButtonStyle}"
+                                IsEnabled="{Binding CanEdit}"
+                                Padding="14,9"
+                                Margin="0,0,6,0" />
+
+                        <Button Grid.Column="1"
+                                Content="{Binding SaveButtonText}"
+                                Command="{Binding SaveCommand}"
+                                Padding="14,9"
+                                Margin="6,0,0,0">
+                            <Button.Style>
+                                <Style TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding IsSaved}" Value="True">
+                                            <Setter Property="Background">
+                                                <Setter.Value>
+                                                    <SolidColorBrush Color="#34C759" />
+                                                </Setter.Value>
+                                            </Setter>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </Button.Style>
+                        </Button>
+                    </Grid>
                 </StackPanel>
             </Border>
-
-            <!-- Save Button -->
-            <Button Content="{Binding SaveButtonText}"
-                    Command="{Binding SaveCommand}"
-                    HorizontalAlignment="Stretch"
-                    Padding="14,9"
-                    Margin="0,2,0,0">
-                <Button.Style>
-                    <Style TargetType="Button" BasedOn="{StaticResource AccentButtonStyle}">
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsSaved}" Value="True">
-                                <Setter Property="Background">
-                                    <Setter.Value>
-                                        <SolidColorBrush Color="#34C759" />
-                                    </Setter.Value>
-                                </Setter>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Button.Style>
-            </Button>
-
-        </StackPanel>
+        </Grid>
     </Border>
 </Window>

--- a/src/Geass/Views/SettingsWindow.xaml.cs
+++ b/src/Geass/Views/SettingsWindow.xaml.cs
@@ -11,6 +11,7 @@ namespace Geass.Views;
 public partial class SettingsWindow : Window
 {
     private bool _isUpdatingPassword;
+    private bool _allowCloseWithoutPrompt;
     private Storyboard? _spinStoryboard;
 
     public SettingsViewModel ViewModel => (SettingsViewModel)DataContext;
@@ -32,6 +33,8 @@ public partial class SettingsWindow : Window
         };
 
         viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        Closing += OnWindowClosing;
+        Closed += OnWindowClosed;
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -184,5 +187,52 @@ public partial class SettingsWindow : Window
             ApiKeyPasswordBox.Visibility = Visibility.Visible;
             ApiKeyPasswordBox.Focus();
         }
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private void OnWindowClosing(object? sender, CancelEventArgs e)
+    {
+        if (_allowCloseWithoutPrompt) return;
+
+        if (ViewModel.IsBusy)
+        {
+            MessageBox.Show(
+                this,
+                "Please wait for the current operation to finish.",
+                "Settings",
+                MessageBoxButton.OK,
+                MessageBoxImage.Information);
+            e.Cancel = true;
+            return;
+        }
+
+        if (!ViewModel.HasUnsavedChanges) return;
+
+        var result = MessageBox.Show(
+            this,
+            "You have unsaved changes. Discard them and close settings?",
+            "Discard changes?",
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning);
+
+        if (result != MessageBoxResult.Yes)
+        {
+            e.Cancel = true;
+            return;
+        }
+
+        _allowCloseWithoutPrompt = true;
+    }
+
+    private void OnWindowClosed(object? sender, EventArgs e)
+    {
+        ViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        ViewModel.Dispose();
+        Closing -= OnWindowClosing;
+        Closed -= OnWindowClosed;
     }
 }

--- a/src/Geass/Views/TranscriptionWindow.xaml
+++ b/src/Geass/Views/TranscriptionWindow.xaml
@@ -43,6 +43,7 @@
         </Border.Effect>
 
         <Border CornerRadius="14" ClipToBounds="True">
+            <Grid>
             <StackPanel>
                 <!-- ═══ COMPACT STATE: Recording / Processing / Transcribing ═══ -->
                 <StackPanel x:Name="CompactPanel"
@@ -108,6 +109,23 @@
                                  Fill="{StaticResource AccentBrush}" Opacity="0.4" />
                     </StackPanel>
 
+                    <!-- Live input meter -->
+                    <Border x:Name="InputLevelMeter"
+                            Width="42"
+                            Height="8"
+                            Margin="0,0,10,0"
+                            CornerRadius="4"
+                            BorderThickness="1"
+                            BorderBrush="#4DFFFFFF"
+                            Background="#1FFFFFFF"
+                            Visibility="Collapsed">
+                        <Border x:Name="InputLevelFill"
+                                Width="0"
+                                HorizontalAlignment="Left"
+                                CornerRadius="3"
+                                Background="{StaticResource AccentBrush}" />
+                    </Border>
+
                     <!-- Status text -->
                     <TextBlock x:Name="StatusText"
                                Text="Listening..."
@@ -164,6 +182,25 @@
                     </Grid>
                 </StackPanel>
             </StackPanel>
+
+            <Border x:Name="TransientToast"
+                    Opacity="0"
+                    Visibility="Collapsed"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Top"
+                    Margin="0,8,0,0"
+                    Padding="10,5"
+                    CornerRadius="999"
+                    BorderThickness="1"
+                    BorderBrush="#55FFFFFF"
+                    Background="#AA1A1A22">
+                <TextBlock x:Name="TransientToastText"
+                           Foreground="#FFF5F5F7"
+                           FontSize="11.5"
+                           FontFamily="Segoe UI Variable, Segoe UI, sans-serif"
+                           FontWeight="Medium" />
+            </Border>
+            </Grid>
         </Border>
     </Border>
 </Window>

--- a/src/Geass/Views/TranscriptionWindow.xaml.cs
+++ b/src/Geass/Views/TranscriptionWindow.xaml.cs
@@ -10,6 +10,8 @@ namespace Geass.Views;
 
 public partial class TranscriptionWindow : Window
 {
+    private const double InputMeterMaxWidth = 40;
+
     public enum ViewState { Recording, Processing, Streaming, Editing }
 
     private ViewState _visualState = ViewState.Recording;
@@ -87,9 +89,11 @@ public partial class TranscriptionWindow : Window
 
         WaveformCanvas.Visibility = Visibility.Visible;
         RecDot.Visibility = Visibility.Visible;
+        InputLevelMeter.Visibility = Visibility.Visible;
+        SetInputLevel(0f);
         Spinner.Visibility = Visibility.Collapsed;
         StreamDotsPanel.Visibility = Visibility.Collapsed;
-        StatusText.Text = "Listening...";
+        SetRecordingStatus("Listening...");
         CompactPanel.Visibility = Visibility.Visible;
         ExpandedPanel.Visibility = Visibility.Collapsed;
 
@@ -125,6 +129,7 @@ public partial class TranscriptionWindow : Window
 
         WaveformCanvas.Visibility = Visibility.Collapsed;
         RecDot.Visibility = Visibility.Collapsed;
+        InputLevelMeter.Visibility = Visibility.Collapsed;
         Spinner.Visibility = Visibility.Visible;
         StreamDotsPanel.Visibility = Visibility.Collapsed;
         StatusText.Text = "Processing...";
@@ -142,6 +147,7 @@ public partial class TranscriptionWindow : Window
         Spinner.Visibility = Visibility.Collapsed;
         WaveformCanvas.Visibility = Visibility.Collapsed;
         RecDot.Visibility = Visibility.Collapsed;
+        InputLevelMeter.Visibility = Visibility.Collapsed;
         StreamDotsPanel.Visibility = Visibility.Visible;
         StatusText.Text = "Transcribing...";
 
@@ -218,9 +224,11 @@ public partial class TranscriptionWindow : Window
 
             WaveformCanvas.Visibility = Visibility.Visible;
             RecDot.Visibility = Visibility.Visible;
+            InputLevelMeter.Visibility = Visibility.Visible;
+            SetInputLevel(0f);
             Spinner.Visibility = Visibility.Collapsed;
             StreamDotsPanel.Visibility = Visibility.Collapsed;
-            StatusText.Text = "Style...";
+            SetRecordingStatus("Style...");
             CompactPanel.Visibility = Visibility.Visible;
 
             StartWaveformAnimation();
@@ -242,6 +250,7 @@ public partial class TranscriptionWindow : Window
 
             WaveformCanvas.Visibility = Visibility.Collapsed;
             RecDot.Visibility = Visibility.Collapsed;
+            InputLevelMeter.Visibility = Visibility.Collapsed;
             Spinner.Visibility = Visibility.Collapsed;
             StreamDotsPanel.Visibility = Visibility.Visible;
             StatusText.Text = "Applying...";
@@ -257,6 +266,45 @@ public partial class TranscriptionWindow : Window
             TranscriptionTextBox.Text = fullText;
             TranscriptionTextBox.CaretIndex = TranscriptionTextBox.Text.Length;
             TranscriptionTextBox.ScrollToEnd();
+        });
+    }
+
+    public void SetRecordingStatus(string text, bool isWarning = false)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            StatusText.Text = text;
+            StatusText.Foreground = isWarning
+                ? new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xC8, 0x6A))
+                : new SolidColorBrush(Color.FromArgb(0xCC, 0xFF, 0xFF, 0xFF));
+        });
+    }
+
+    public void SetInputLevel(float normalizedLevel)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            var clamped = Math.Clamp(normalizedLevel, 0f, 1f);
+            InputLevelFill.Width = InputMeterMaxWidth * clamped;
+        });
+    }
+
+    public void ShowTransientToast(string message)
+    {
+        Dispatcher.Invoke(() =>
+        {
+            TransientToastText.Text = message;
+            TransientToast.Visibility = Visibility.Visible;
+            TransientToast.BeginAnimation(OpacityProperty, null);
+
+            var toastAnim = new DoubleAnimationUsingKeyFrames();
+            toastAnim.KeyFrames.Add(new EasingDoubleKeyFrame(0, KT(0)));
+            toastAnim.KeyFrames.Add(new EasingDoubleKeyFrame(1, KT(0.12)));
+            toastAnim.KeyFrames.Add(new EasingDoubleKeyFrame(1, KT(1.1)));
+            toastAnim.KeyFrames.Add(new EasingDoubleKeyFrame(0, KT(1.45)));
+            toastAnim.Completed += (_, _) => TransientToast.Visibility = Visibility.Collapsed;
+
+            TransientToast.BeginAnimation(OpacityProperty, toastAnim);
         });
     }
 


### PR DESCRIPTION
Closes #2 This PR includes settings scrolling/save UX fixes plus real time recording feedback improvements (level meter, waiting-for-speech/silence states, muted/no-input/clipping handling, and non-blocking no-speech toast).
Validation: local dotnet build passed with no errors.